### PR TITLE
feat(swagger): add schema reference support

### DIFF
--- a/src/swagger-patch.ts
+++ b/src/swagger-patch.ts
@@ -1,21 +1,67 @@
 import { Type as NestType } from '@nestjs/common';
 import { SchemaObjectFactory } from '@nestjs/swagger/dist/services/schema-object-factory.js';
+import { Type } from '@sinclair/typebox';
+import { TSchema } from '@sinclair/typebox/type';
 
 import { isSchemaValidator } from './decorators.js';
 
-export function patchNestJsSwagger() {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if ((SchemaObjectFactory.prototype as any).__primatePatched) return;
-    const defaultExplore = SchemaObjectFactory.prototype.exploreModelSchema;
+export function patchNestJsSwagger(): void {
+    if ((SchemaObjectFactory.prototype as SchemaObjectFactory & { __primatePatched?: boolean }).__primatePatched) {
+        return;
+    }
 
-    const extendedExplore: SchemaObjectFactory['exploreModelSchema'] = function exploreModelSchema(
+    const defaultExplore = SchemaObjectFactory.prototype.exploreModelSchema;
+    const seenSchemaIds = new Set<string>();
+
+    function flattenSchema(schema: TSchema, schemas: Record<string, TSchema>): TSchema {
+        if (schema === null || typeof schema !== 'object') {
+            return schema as TSchema;
+        }
+
+        // If this is a schema with $id, register it and return a reference
+        if (schema.$id && typeof schema.$id === 'string') {
+            const { $id: schemaId } = schema;
+
+            if (!seenSchemaIds.has(schemaId)) {
+                seenSchemaIds.add(schemaId);
+                // Create a copy without $id and recursively flatten
+                const { $id: _id, ...schemaWithoutId } = schema;
+                if (schemas[schemaId]) {
+                    console.warn(`Schema with ID ${schemaId} already exists. Overwriting...`);
+                }
+                schemas[schemaId] = flattenSchema(schemaWithoutId as TSchema, schemas);
+
+                return Type.Ref(schemaId);
+            }
+        }
+
+        // For schemas without $id, keep them nested but process their contents
+        const result = { ...schema } as TSchema;
+
+        // Handle array items
+        if (schema.type === 'array' && schema.items && typeof schema.items === 'object') {
+            result.items = flattenSchema(schema.items as TSchema, schemas);
+        }
+
+        // Handle object properties
+        if (schema.type === 'object' && schema.properties && typeof schema.properties === 'object') {
+            result.properties = {};
+            for (const [key, value] of Object.entries(schema.properties)) {
+                result.properties[key] = flattenSchema(value as TSchema, schemas);
+            }
+        }
+
+        return result;
+    }
+
+    const extendedExplore = function (
         this: SchemaObjectFactory,
-        type,
-        schemas,
-        schemaRefsStack
-    ) {
-        if (this['isLazyTypeFunc'](type)) {
-            const factory = type as () => NestType<unknown>;
+        type: NestType,
+        schemas: Record<string, TSchema>,
+        schemaRefsStack: string[]
+    ): string {
+        if (typeof type === 'function' && this['isLazyTypeFunc'](type)) {
+            const factory = type as unknown as () => NestType;
             type = factory();
         }
 
@@ -23,12 +69,19 @@ export function patchNestJsSwagger() {
             return defaultExplore.apply(this, [type, schemas, schemaRefsStack]);
         }
 
-        schemas[type.name] = type.schema;
+        const schema = type.schema;
+        if (!schema || typeof schema !== 'object') {
+            console.warn('Invalid schema provided to exploreModelSchema');
+            return type.name;
+        }
+
+        // Flatten the schema and register it
+        const flattenedSchema = flattenSchema(schema as TSchema, schemas);
+        schemas[type.name] = flattenedSchema;
 
         return type.name;
     };
 
     SchemaObjectFactory.prototype.exploreModelSchema = extendedExplore;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (SchemaObjectFactory.prototype as any).__primatePatched = true;
+    (SchemaObjectFactory.prototype as SchemaObjectFactory & { __primatePatched?: boolean }).__primatePatched = true;
 }


### PR DESCRIPTION
- Add support for schema references using  and Type.Ref()

- Implement schema flattening to properly handle nested schemas

- Add reference tracking to prevent duplicate schema registrations

- Maintain proper schema structure while supporting references

This change improves OpenAPI documentation by properly handling schema references instead of inlining all nested schemas. Schemas with  are now referenced using Type.Ref(), reducing duplication and making the documentation more maintainable.